### PR TITLE
Fill buffer with random bytes before sending

### DIFF
--- a/goben/client.go
+++ b/goben/client.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"math/rand"
 	"net"
 	"runtime"
 	"sync"
@@ -230,6 +231,7 @@ func (a *account) average(start time.Time, conn, label, cpsLabel string) {
 func workLoop(conn, label, cpsLabel string, f call, bufSize int, reportInterval time.Duration, maxSpeed float64, stat *ChartData) {
 
 	buf := make([]byte, bufSize)
+	rand.Read(buf)
 
 	start := time.Now()
 	acc := &account{}


### PR DESCRIPTION
Some network devices will cache and/or compress data in TCP/UDP streams.
To give a more accurate bandwidth measurement, the data being sent in
the stream should be randomized.