### PR TITLE
Append remote connection to output files

### DIFF
--- a/goben/client.go
+++ b/goben/client.go
@@ -125,7 +125,7 @@ func handleConnectionClient(app *config, wg *sync.WaitGroup, conn net.Conn, c, c
 	}
 
 	if app.csv != "" {
-		filename := fmt.Sprintf(app.csv, c)
+		filename := fmt.Sprintf(app.csv, c, conn.RemoteAddr())
 		log.Printf("exporting CSV test results to: %s", filename)
 		errExport := exportCsv(filename, &info)
 		if errExport != nil {
@@ -134,7 +134,7 @@ func handleConnectionClient(app *config, wg *sync.WaitGroup, conn net.Conn, c, c
 	}
 
 	if app.export != "" {
-		filename := fmt.Sprintf(app.export, c)
+		filename := fmt.Sprintf(app.export, c, conn.RemoteAddr())
 		log.Printf("exporting YAML test results to: %s", filename)
 		errExport := export(filename, &info)
 		if errExport != nil {
@@ -143,7 +143,7 @@ func handleConnectionClient(app *config, wg *sync.WaitGroup, conn net.Conn, c, c
 	}
 
 	if app.chart != "" {
-		filename := fmt.Sprintf(app.chart, c)
+		filename := fmt.Sprintf(app.chart, c, conn.RemoteAddr())
 		log.Printf("rendering chart to: %s", filename)
 		errRender := chartRender(filename, &info.Input, &info.Output)
 		if errRender != nil {
@@ -151,7 +151,7 @@ func handleConnectionClient(app *config, wg *sync.WaitGroup, conn net.Conn, c, c
 		}
 	}
 
-	plotascii(&info)
+	plotascii(&info, conn.RemoteAddr().String(), c)
 
 	log.Printf("handleConnectionClient: closing: %d/%d %v", c, connections, conn.RemoteAddr())
 }

--- a/goben/main.go
+++ b/goben/main.go
@@ -67,23 +67,23 @@ func main() {
 	flag.BoolVar(&app.opt.PassiveServer, "passiveServer", false, "suppress server writes")
 	flag.Float64Var(&app.opt.MaxSpeed, "maxSpeed", 0, "bandwidth limit in mbps (0 means unlimited)")
 	flag.BoolVar(&app.udp, "udp", false, "run client in UDP mode")
-	flag.StringVar(&app.chart, "chart", "", "output filename for rendering chart on client\nexample: -chart chart-%d.png")
-	flag.StringVar(&app.export, "export", "", "output filename for YAML exporting test results on client\nexample: -export export-%d.yaml")
-	flag.StringVar(&app.csv, "csv", "", "output filename for CSV exporting test results on client\nexample: -csv export-%d.csv")
+	flag.StringVar(&app.chart, "chart", "", "output filename for rendering chart on client\n'%d' is parallel connection index to host\n'%s' is hostname:port\nexample: -chart chart-%d-%s.png")
+	flag.StringVar(&app.export, "export", "", "output filename for YAML exporting test results on client\n'%d' is parallel connection index to host\n'%s' is hostname:port\nexample: -export export-%d-%s.yaml")
+	flag.StringVar(&app.csv, "csv", "", "output filename for CSV exporting test results on client\n'%d' is parallel connection index to host\n'%s' is hostname:port\nexample: -csv export-%d-%s.csv")
 	flag.BoolVar(&app.ascii, "ascii", true, "plot ascii chart")
 
 	flag.Parse()
 
-	if app.chart != "" && !strings.Contains(app.chart, "%d") {
-		log.Panicf("bad chart: filename requires '%%d': %s", app.chart)
+	if app.chart != "" && !strings.Contains(app.chart, "%d") && !strings.Contains(app.chart, "%s") {
+		log.Panicf("bad chart: filename requires '%%d' and '%%s': %s", app.chart)
 	}
 
-	if app.export != "" && !strings.Contains(app.export, "%d") {
-		log.Panicf("bad export: filename requires '%%d': %s", app.export)
+	if app.export != "" && !strings.Contains(app.export, "%d") && !strings.Contains(app.export, "%s") {
+		log.Panicf("bad export: filename requires '%%d' and '%%s': %s", app.export)
 	}
 
-	if app.csv != "" && !strings.Contains(app.csv, "%d") {
-		log.Panicf("bad csv: filename requires '%%d': %s", app.csv)
+	if app.csv != "" && !strings.Contains(app.csv, "%d") && !strings.Contains(app.csv, "%s") {
+		log.Panicf("bad csv: filename requires '%%d' and '%%s': %s", app.csv)
 	}
 
 	app.reportInterval = defaultTimeUnit(app.reportInterval)

--- a/goben/plotascii.go
+++ b/goben/plotascii.go
@@ -7,20 +7,22 @@ import (
 	"github.com/guptarohit/asciigraph"
 )
 
-func plotascii(info *ExportInfo) {
+func plotascii(info *ExportInfo, remote string, index int) {
 
 	height := 10
 	width := 70
 
 	if len(info.Input.YValues) > 0 {
-		log.Println("input:")
-		input := asciigraph.Plot(info.Input.YValues, asciigraph.Caption("Input Mbps"), asciigraph.Height(height), asciigraph.Width(width))
+		caption := fmt.Sprintf("Input Mbps: %s Connection %d", remote, index)
+		log.Printf("%s input:", remote)
+		input := asciigraph.Plot(info.Input.YValues, asciigraph.Caption(caption), asciigraph.Height(height), asciigraph.Width(width))
 		fmt.Println(input)
 	}
 
 	if len(info.Output.YValues) > 0 {
-		log.Println("output:")
-		output := asciigraph.Plot(info.Output.YValues, asciigraph.Caption("Output Mbps"), asciigraph.Height(height), asciigraph.Width(width))
+		caption := fmt.Sprintf("Output Mbps: %s Connection %d", remote, index)
+		log.Printf("%s output:", remote)
+		output := asciigraph.Plot(info.Output.YValues, asciigraph.Caption(caption), asciigraph.Height(height), asciigraph.Width(width))
 		fmt.Println(output)
 	}
 }


### PR DESCRIPTION
Add %s formatting to output file names. This way, output files do not
get overwritten by the different threads and output files can be
distinguished by the remote connection.
Also append the remote host connection and thread index to the ASCII graph caption to
clarify output and be similar to the output file names