### PR TITLE
Fix unchecked error returns detected by errcheck

### DIFF
--- a/cmd/goben/main.go
+++ b/cmd/goben/main.go
@@ -47,5 +47,7 @@ func main() {
 	}
 
 	log.Printf("client mode, %s protocol", proto)
-	goben.Open(&app)
+	if _, err := goben.Open(&app); err != nil {
+		log.Fatalf("Failed to open connection: %v", err)
+	}
 }

--- a/cmd/goben/main_test.go
+++ b/cmd/goben/main_test.go
@@ -84,7 +84,6 @@ func TestEndToEndTLS(t *testing.T) {
 	client.TLSCA = "../../test/certs/ca.crt"
 	client.TLSCert = "../../test/certs/client.crt"
 	client.TLSKey = "../../test/certs/client.key"
-	goben.ValidateAndUpdateConfig(client)
 	assert.NoError(t, goben.ValidateAndUpdateConfig(client))
 
 	// a server config

--- a/goben/config.go
+++ b/goben/config.go
@@ -79,7 +79,7 @@ func NewDefaultConfig() *Config {
 
 	flagSet := flag.FlagSet{}
 	result.AssignFlags(&flagSet)
-	flagSet.Parse([]string{})
+	_ = flagSet.Parse([]string{})
 	return &result
 }
 


### PR DESCRIPTION
This PR fixes unchecked error return values that were detected by golangci-lint's errcheck linter.

## Changes
- Add error handling for `goben.Open()` in main.go
- Remove duplicate `ValidateAndUpdateConfig()` call in main_test.go  
- Explicitly ignore `flagSet.Parse()` error when parsing empty args in config.go

## Linter output before fix
```
goben/config.go:82:15: Error return value of `flagSet.Parse` is not checked (errcheck)
cmd/goben/main.go:50:12: Error return value of `goben.Open` is not checked (errcheck)
cmd/goben/main_test.go:87:31: Error return value of `goben.ValidateAndUpdateConfig` is not checked (errcheck)
```

All tests pass after these changes.