### PR TITLE
Add graceful shutdown support

### DIFF
--- a/cmd/goben/main.go
+++ b/cmd/goben/main.go
@@ -2,11 +2,15 @@
 package main
 
 import (
+	"context"
 	"flag"
 	"log"
+	"os"
+	"os/signal"
 	"runtime"
 	"strconv"
 	"sync"
+	"syscall"
 
 	"github.com/udhos/goben/goben"
 )
@@ -15,7 +19,6 @@ func main() {
 
 	app := goben.Config{}
 
-	// use the global flagset
 	app.AssignFlags(flag.CommandLine)
 	flag.Parse()
 
@@ -24,18 +27,30 @@ func main() {
 		app.Connections, app.DefaultPort, app.Listeners, app.Hosts)
 	log.Printf("reportInterval=%s totalDuration=%s", app.Opt.ReportInterval, app.Opt.TotalDuration)
 
+	ctx, cancel := context.WithCancel(context.Background())
+
+	sigChan := make(chan os.Signal, 1)
+	signal.Notify(sigChan, os.Interrupt, syscall.SIGTERM)
+
+	go func() {
+		sig := <-sigChan
+		log.Printf("Received signal: %v, gracefully shutting down...", sig)
+		cancel()
+	}()
+
 	if len(app.Hosts) == 0 {
 		log.Printf("server mode (use -hosts to switch to client mode)")
 
 		var wg sync.WaitGroup
-		wg.Add(1)
-		listenSuccess := goben.Serve(&app, &wg)
+		listenSuccess := goben.Serve(ctx, &app, &wg)
 		if !listenSuccess {
 			log.Println("server failed to listen")
+			cancel()
+			return
 		}
 
-		// wait until complete
-		wg.Wait()
+		<-ctx.Done()
+		wg.Wait() // Wait for listener goroutines to finish cleanup
 		return
 	}
 
@@ -47,7 +62,8 @@ func main() {
 	}
 
 	log.Printf("client mode, %s protocol", proto)
-	if _, err := goben.Open(&app); err != nil {
+
+	if _, err := goben.Open(ctx, &app); err != nil {
 		log.Fatalf("Failed to open connection: %v", err)
 	}
 }

--- a/cmd/goben/main_test.go
+++ b/cmd/goben/main_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"sync"
 	"testing"
 	"time"
@@ -24,7 +25,7 @@ func TestInvalidConfig(t *testing.T) {
 	assert.Equal(t, nil, goben.ValidateAndUpdateConfig(client))
 
 	// launch client (this will fail)
-	_, err := goben.Open(client)
+	_, err := goben.Open(context.Background(), client)
 	assert.Error(t, err)
 }
 
@@ -56,11 +57,11 @@ func TestEndToEndInvalidTLSConfig(t *testing.T) {
 	// launch server
 	var wg sync.WaitGroup
 	wg.Add(1)
-	listenSuccess := goben.Serve(server, &wg)
+	listenSuccess := goben.Serve(context.Background(), server, &wg)
 	assert.False(t, listenSuccess)
 
 	// launch client
-	clientStats, err := goben.Open(client)
+	clientStats, err := goben.Open(context.Background(), client)
 	assert.Error(t, err)
 	assert.Equal(t, clientStats.TotalDuration, time.Duration(0*time.Second))
 	assert.Equal(t, clientStats.ReadMbps, float64(0))
@@ -100,13 +101,13 @@ func TestEndToEndTLS(t *testing.T) {
 	// launch server
 	var wg sync.WaitGroup
 	wg.Add(1)
-	listenSuccess := goben.Serve(server, &wg)
+	listenSuccess := goben.Serve(context.Background(), server, &wg)
 	if !listenSuccess {
 		t.Error("server failed to listen")
 	}
 
 	// launch client
-	clientStats, err := goben.Open(client)
+	clientStats, err := goben.Open(context.Background(), client)
 	assert.NoError(t, err)
 	assert.Equal(t, clientStats.TotalDuration, time.Duration(2*time.Second))
 	assert.Greater(t, clientStats.ReadMbps, float64(100))
@@ -138,13 +139,13 @@ func TestEndToEndTCP(t *testing.T) {
 	// launch server
 	var wg sync.WaitGroup
 	wg.Add(1)
-	listenSuccess := goben.Serve(server, &wg)
+	listenSuccess := goben.Serve(context.Background(), server, &wg)
 	if !listenSuccess {
 		t.Error("server failed to listen")
 	}
 
 	// launch client
-	clientStats, err := goben.Open(client)
+	clientStats, err := goben.Open(context.Background(), client)
 	assert.NoError(t, err)
 	assert.Equal(t, clientStats.TotalDuration, time.Duration(2*time.Second))
 	assert.Greater(t, clientStats.ReadMbps, float64(100))
@@ -176,13 +177,13 @@ func TestEndToEndTCPFallback(t *testing.T) {
 	// launch server
 	var wg sync.WaitGroup
 	wg.Add(1)
-	listenSuccess := goben.Serve(server, &wg)
+	listenSuccess := goben.Serve(context.Background(), server, &wg)
 	if !listenSuccess {
 		t.Error("server failed to listen")
 	}
 
 	// launch client
-	clientStats, err := goben.Open(client)
+	clientStats, err := goben.Open(context.Background(), client)
 	assert.NoError(t, err)
 	assert.Equal(t, clientStats.TotalDuration, time.Duration(2*time.Second))
 	assert.Greater(t, clientStats.ReadMbps, float64(100))

--- a/goben/client.go
+++ b/goben/client.go
@@ -3,6 +3,7 @@ package goben
 
 import (
 	"bytes"
+	"context"
 	"crypto/rand"
 	"crypto/tls"
 	"crypto/x509"
@@ -28,7 +29,7 @@ type ClientStats struct {
 }
 
 // Open opens a client with a config and performs a test.
-func Open(app *Config) (ClientStats, error) {
+func Open(ctx context.Context, app *Config) (ClientStats, error) {
 
 	// validate the config first
 	if err := ValidateAndUpdateConfig(app); err != nil {
@@ -81,7 +82,7 @@ func Open(app *Config) (ClientStats, error) {
 				log.Printf("open: trying TLS")
 				conn, errDialTLS := tlsDial(dialer, proto, hh, app)
 				if errDialTLS == nil {
-					spawnClient(app, &wg, conn, i, app.Connections, true, &aggReader, &aggWriter)
+					spawnClient(ctx, app, &wg, conn, i, app.Connections, true, &aggReader, &aggWriter)
 					successfulConnections++
 					continue
 				}
@@ -102,7 +103,7 @@ func Open(app *Config) (ClientStats, error) {
 					log.Printf("open: dial %s: %s: %v", proto, hh, errDial)
 					continue
 				}
-				spawnClient(app, &wg, conn, i, app.Connections, false, &aggReader, &aggWriter)
+				spawnClient(ctx, app, &wg, conn, i, app.Connections, false, &aggReader, &aggWriter)
 				successfulConnections++
 			}
 		}
@@ -127,9 +128,9 @@ func Open(app *Config) (ClientStats, error) {
 	}, nil
 }
 
-func spawnClient(app *Config, wg *sync.WaitGroup, conn net.Conn, c, connections int, isTLS bool, aggReader, aggWriter *aggregate) {
+func spawnClient(ctx context.Context, app *Config, wg *sync.WaitGroup, conn net.Conn, c, connections int, isTLS bool, aggReader, aggWriter *aggregate) {
 	wg.Add(1)
-	go handleConnectionClient(app, wg, conn, c, connections, isTLS, aggReader, aggWriter)
+	go handleConnectionClient(ctx, app, wg, conn, c, connections, isTLS, aggReader, aggWriter)
 }
 
 func tlsDial(dialer net.Dialer, proto, h string, app *Config) (net.Conn, error) {
@@ -220,20 +221,17 @@ func sendOptions(app *Config, conn io.Writer) error {
 	return nil
 }
 
-func handleConnectionClient(app *Config, wg *sync.WaitGroup, conn net.Conn, c, connections int, isTLS bool, aggReader, aggWriter *aggregate) {
+func handleConnectionClient(ctx context.Context, app *Config, wg *sync.WaitGroup, conn net.Conn, c, connections int, isTLS bool, aggReader, aggWriter *aggregate) {
 	defer wg.Done()
 
 	log.Printf("handleConnectionClient: starting %s %d/%d %v", protoLabel(isTLS), c, connections, conn.RemoteAddr())
 
-	// send options
 	if errOpt := sendOptions(app, conn); errOpt != nil {
 		return
 	}
 	opt := app.Opt
 	log.Printf("handleConnectionClient: options sent: %v", opt)
 
-	// receive ack
-	//log.Printf("handleConnectionClient: FIXME WRITEME server does not send ack for UDP")
 	if !app.UDP {
 		var a ack
 		if errAck := ackRecv(app.UDP, conn, &a); errAck != nil {
@@ -261,23 +259,27 @@ func handleConnectionClient(app *Config, wg *sync.WaitGroup, conn net.Conn, c, c
 
 	bufSizeIn, bufSizeOut := getBufSize(opt, app.UDP)
 
-	go clientReader(conn, c, connections, doneReader, bufSizeIn, opt, input, aggReader)
+	go clientReader(ctx, conn, c, connections, doneReader, bufSizeIn, opt, input, aggReader)
 	if !app.PassiveClient {
-		go clientWriter(conn, c, connections, doneWriter, bufSizeOut, opt, output, aggWriter)
+		go clientWriter(ctx, conn, c, connections, doneWriter, bufSizeOut, opt, output, aggWriter)
 	}
 
 	tickerPeriod := time.NewTimer(app.Opt.TotalDuration)
 
-	<-tickerPeriod.C
-	log.Printf("handleConnectionClient: %v timer", app.Opt.TotalDuration)
+	select {
+	case <-tickerPeriod.C:
+		log.Printf("handleConnectionClient: %v timer", app.Opt.TotalDuration)
+	case <-ctx.Done():
+		log.Printf("handleConnectionClient: received shutdown signal")
+	}
 
 	tickerPeriod.Stop()
 
-	conn.Close() // force reader/writer to quit
+	conn.Close()
 
-	<-doneReader // wait reader exit
+	<-doneReader
 	if !app.PassiveClient {
-		<-doneWriter // wait writer exit
+		<-doneWriter
 	}
 
 	if app.CSV != "" {
@@ -326,28 +328,28 @@ func getBufSize(opt Options, isUDP bool) (bufSizeIn int, bufSizeOut int) {
 	return
 }
 
-func clientReader(conn net.Conn, c, connections int, done chan struct{}, bufSize int, opt Options, stat *ChartData, agg *aggregate) {
+func clientReader(ctx context.Context, conn net.Conn, c, connections int, done chan struct{}, bufSize int, opt Options, stat *ChartData, agg *aggregate) {
 	log.Printf("clientReader: starting: %d/%d %v", c, connections, conn.RemoteAddr())
 
 	connIndex := fmt.Sprintf("%d/%d", c, connections)
 
 	buf := make([]byte, bufSize)
 
-	workLoop(connIndex, "clientReader", "rcv/s", conn.Read, buf, opt.ReportInterval, 0, stat, agg)
+	workLoop(ctx, connIndex, "clientReader", "rcv/s", conn.Read, buf, opt.ReportInterval, 0, stat, agg)
 
 	close(done)
 
 	log.Printf("clientReader: exiting: %d/%d %v", c, connections, conn.RemoteAddr())
 }
 
-func clientWriter(conn net.Conn, c, connections int, done chan struct{}, bufSize int, opt Options, stat *ChartData, agg *aggregate) {
+func clientWriter(ctx context.Context, conn net.Conn, c, connections int, done chan struct{}, bufSize int, opt Options, stat *ChartData, agg *aggregate) {
 	log.Printf("clientWriter: starting: %d/%d %v", c, connections, conn.RemoteAddr())
 
 	connIndex := fmt.Sprintf("%d/%d", c, connections)
 
 	buf := randBuf(bufSize)
 
-	workLoop(connIndex, "clientWriter", "snd/s", conn.Write, buf, opt.ReportInterval, opt.MaxSpeed, stat, agg)
+	workLoop(ctx, connIndex, "clientWriter", "snd/s", conn.Write, buf, opt.ReportInterval, opt.MaxSpeed, stat, agg)
 
 	close(done)
 
@@ -423,13 +425,22 @@ func (a *account) average(start time.Time, conn, label, cpsLabel string, agg *ag
 	agg.mutex.Unlock()
 }
 
-func workLoop(conn, label, cpsLabel string, f call, buf []byte, reportInterval time.Duration, maxSpeed float64, stat *ChartData, agg *aggregate) {
+func workLoop(ctx context.Context, conn, label, cpsLabel string, f call, buf []byte, reportInterval time.Duration, maxSpeed float64, stat *ChartData, agg *aggregate) {
 
 	start := time.Now()
 	acc := &account{}
 	acc.prevTime = start
 
 	for {
+		select {
+		case <-ctx.Done():
+			log.Printf("workLoop: %s %s: shutdown requested", conn, label)
+			acc.update(0, reportInterval, conn, label, cpsLabel, stat, true)
+			acc.average(start, conn, label, cpsLabel, agg)
+			return
+		default:
+		}
+
 		runtime.Gosched()
 
 		if maxSpeed > 0 {

--- a/goben/config.go
+++ b/goben/config.go
@@ -149,16 +149,6 @@ func ValidateAndUpdateConfig(app *Config) error {
 	return nil
 }
 
-// ValidateAndUpdateServerConfig validates and updates the config.
-// It will set internal values necessary for successful completion.
-func ValidateAndUpdateServerConfig(app *Config) error {
-	if len(app.Listeners) == 0 {
-		app.Listeners = []string{app.DefaultPort}
-	}
-
-	return nil
-}
-
 // append "s" (second) to time string
 func defaultTimeUnit(s string) string {
 	if s == "" {

--- a/goben/server.go
+++ b/goben/server.go
@@ -2,6 +2,7 @@ package goben
 
 import (
 	"bytes"
+	"context"
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/gob"
@@ -14,7 +15,7 @@ import (
 )
 
 // Serve starts a server with a given configuration.
-func Serve(app *Config, wg *sync.WaitGroup) bool {
+func Serve(ctx context.Context, app *Config, wg *sync.WaitGroup) bool {
 
 	// validate the config
 	if err := ValidateAndUpdateConfig(app); err != nil {
@@ -43,8 +44,8 @@ func Serve(app *Config, wg *sync.WaitGroup) bool {
 	successfulListeners := 0
 	for _, h := range app.Listeners {
 		hh := appendPortIfMissing(h, app.DefaultPort)
-		tcpSuccess := listenTCP(app, wg, hh)
-		udpSuccess := listenUDP(app, wg, hh)
+		tcpSuccess := listenTCP(ctx, app, wg, hh)
+		udpSuccess := listenUDP(ctx, app, wg, hh)
 		if tcpSuccess || udpSuccess {
 			successfulListeners++
 		}
@@ -65,14 +66,14 @@ func fileExists(path string) bool {
 	return err == nil
 }
 
-func listenTCP(app *Config, wg *sync.WaitGroup, h string) bool {
+func listenTCP(ctx context.Context, app *Config, wg *sync.WaitGroup, h string) bool {
 
 	// first try TLS
 	if app.TLS {
 		log.Printf("listenTCP: spawning TLS listener: %s", h)
 		listener, errTLS := listenTLS(app, h)
 		if errTLS == nil {
-			spawnAcceptLoopTCP(wg, listener, true)
+			spawnAcceptLoopTCP(ctx, wg, listener, true)
 			return true
 		}
 		log.Printf("listenTLS: %v", errTLS)
@@ -97,7 +98,7 @@ func listenTCP(app *Config, wg *sync.WaitGroup, h string) bool {
 			log.Printf("listenTCP: TLS=%v %s: %v", app.TLS, h, errListen)
 			return false
 		}
-		spawnAcceptLoopTCP(wg, listener, false)
+		spawnAcceptLoopTCP(ctx, wg, listener, false)
 		return true
 	}
 
@@ -106,9 +107,9 @@ func listenTCP(app *Config, wg *sync.WaitGroup, h string) bool {
 	return false
 }
 
-func spawnAcceptLoopTCP(wg *sync.WaitGroup, listener net.Listener, isTLS bool) {
+func spawnAcceptLoopTCP(ctx context.Context, wg *sync.WaitGroup, listener net.Listener, isTLS bool) {
 	wg.Add(1)
-	go handleTCP(wg, listener, isTLS)
+	go handleTCP(ctx, wg, listener, isTLS)
 }
 
 func listenTLS(app *Config, h string) (net.Listener, error) {
@@ -149,7 +150,7 @@ func listenTLS(app *Config, h string) (net.Listener, error) {
 	return listener, errListen
 }
 
-func listenUDP(app *Config, wg *sync.WaitGroup, h string) bool {
+func listenUDP(ctx context.Context, app *Config, wg *sync.WaitGroup, h string) bool {
 	if app.UDP {
 		log.Printf("serve: spawning UDP listener: %s", h)
 
@@ -166,7 +167,7 @@ func listenUDP(app *Config, wg *sync.WaitGroup, h string) bool {
 		}
 
 		wg.Add(1)
-		go handleUDP(app, wg, conn)
+		go handleUDP(ctx, app, wg, conn)
 	} else {
 		log.Print("listenUDP: UDP disabled")
 		return false
@@ -195,8 +196,13 @@ LOOP:
 	return host + port
 }
 
-func handleTCP(wg *sync.WaitGroup, listener net.Listener, isTLS bool) {
+func handleTCP(ctx context.Context, wg *sync.WaitGroup, listener net.Listener, isTLS bool) {
 	defer wg.Done()
+
+	go func() {
+		<-ctx.Done()
+		listener.Close()
+	}()
 
 	var id int
 
@@ -206,10 +212,16 @@ func handleTCP(wg *sync.WaitGroup, listener net.Listener, isTLS bool) {
 	for {
 		conn, errAccept := listener.Accept()
 		if errAccept != nil {
-			log.Printf("handle: accept: %v", errAccept)
-			break
+			select {
+			case <-ctx.Done():
+				log.Printf("handleTCP: shutdown requested")
+				return
+			default:
+				log.Printf("handle: accept: %v", errAccept)
+				return
+			}
 		}
-		go handleConnection(conn, id, 0, isTLS, &aggReader, &aggWriter)
+		go handleConnection(ctx, conn, id, 0, isTLS, &aggReader, &aggWriter)
 		id++
 	}
 }
@@ -222,8 +234,13 @@ type udpInfo struct {
 	id     int
 }
 
-func handleUDP(app *Config, wg *sync.WaitGroup, conn *net.UDPConn) {
+func handleUDP(ctx context.Context, app *Config, wg *sync.WaitGroup, conn *net.UDPConn) {
 	defer wg.Done()
+
+	go func() {
+		<-ctx.Done()
+		conn.Close()
+	}()
 
 	tab := map[string]*udpInfo{}
 
@@ -237,8 +254,21 @@ func handleUDP(app *Config, wg *sync.WaitGroup, conn *net.UDPConn) {
 	for {
 		var info *udpInfo
 		n, src, errRead := conn.ReadFromUDP(buf)
+		if errRead != nil {
+			select {
+			case <-ctx.Done():
+				log.Printf("handleUDP: shutdown requested")
+				return
+			default:
+				if src == nil {
+					log.Printf("handleUDP: read nil src: error: %v", errRead)
+					continue
+				}
+				log.Printf("handleUDP: read error: %v", errRead)
+				continue
+			}
+		}
 		if src == nil {
-			log.Printf("handleUDP: read nil src: error: %v", errRead)
 			continue
 		}
 		var found bool
@@ -264,8 +294,8 @@ func handleUDP(app *Config, wg *sync.WaitGroup, conn *net.UDPConn) {
 			log.Printf("handleUDP: options received: %v", info.opt)
 
 			if !info.opt.PassiveServer {
-				opt := info.opt // copy for gorouting
-				go serverWriterTo(conn, opt, src, info.acc, info.id, 0, &aggWriter)
+				opt := info.opt
+				go serverWriterTo(ctx, conn, opt, src, info.acc, info.id, 0, &aggWriter)
 			}
 
 			continue
@@ -285,17 +315,15 @@ func handleUDP(app *Config, wg *sync.WaitGroup, conn *net.UDPConn) {
 			continue
 		}
 
-		// account read from UDP socket
 		info.acc.update(n, info.opt.ReportInterval, connIndex, "handleUDP", "rcv/s", nil, false)
 	}
 }
 
-func handleConnection(conn net.Conn, c, connections int, isTLS bool, aggReader, aggWriter *aggregate) {
+func handleConnection(ctx context.Context, conn net.Conn, c, connections int, isTLS bool, aggReader, aggWriter *aggregate) {
 	defer conn.Close()
 
 	log.Printf("handleConnection: incoming: %s %v", protoLabel(isTLS), conn.RemoteAddr())
 
-	// ensure the Handshake if this is a TLS connection
 	tlscon, ok := conn.(*tls.Conn)
 	if ok {
 		err := tlscon.Handshake()
@@ -314,7 +342,6 @@ func handleConnection(conn net.Conn, c, connections int, isTLS bool, aggReader, 
 		log.Print("handleConnection: not TLS")
 	}
 
-	// receive options
 	var opt Options
 	dec := gob.NewDecoder(conn)
 	if errOpt := dec.Decode(&opt); errOpt != nil {
@@ -331,30 +358,33 @@ func handleConnection(conn net.Conn, c, connections int, isTLS bool, aggReader, 
 		log.Printf("handleConnection: clientVersion=%s", clientVersion)
 	}
 
-	// send ack
 	a := newAck()
 	if errAck := ackSend(false, conn, a); errAck != nil {
 		log.Printf("handleConnection: sending ack: %v", errAck)
 		return
 	}
 
-	go serverReader(conn, opt, c, connections, isTLS, aggReader)
+	go serverReader(ctx, conn, opt, c, connections, isTLS, aggReader)
 
 	if !opt.PassiveServer {
-		go serverWriter(conn, opt, c, connections, isTLS, aggWriter)
+		go serverWriter(ctx, conn, opt, c, connections, isTLS, aggWriter)
 	}
 
 	tickerPeriod := time.NewTimer(opt.TotalDuration)
 
-	<-tickerPeriod.C
-	log.Printf("handleConnection: %v timer", opt.TotalDuration)
+	select {
+	case <-tickerPeriod.C:
+		log.Printf("handleConnection: %v timer", opt.TotalDuration)
+	case <-ctx.Done():
+		log.Printf("handleConnection: received shutdown signal")
+	}
 
 	tickerPeriod.Stop()
 
 	log.Printf("handleConnection: closing: %v", conn.RemoteAddr())
 }
 
-func serverReader(conn net.Conn, opt Options, c, connections int, isTLS bool, agg *aggregate) {
+func serverReader(ctx context.Context, conn net.Conn, opt Options, c, connections int, isTLS bool, agg *aggregate) {
 
 	log.Printf("serverReader: starting: %s %v", protoLabel(isTLS), conn.RemoteAddr())
 
@@ -362,7 +392,7 @@ func serverReader(conn net.Conn, opt Options, c, connections int, isTLS bool, ag
 
 	buf := make([]byte, opt.TCPReadSize)
 
-	workLoop(connIndex, "serverReader", "rcv/s", conn.Read, buf, opt.ReportInterval, 0, nil, agg)
+	workLoop(ctx, connIndex, "serverReader", "rcv/s", conn.Read, buf, opt.ReportInterval, 0, nil, agg)
 
 	log.Printf("serverReader: exiting: %v", conn.RemoteAddr())
 }
@@ -374,7 +404,7 @@ func protoLabel(isTLS bool) string {
 	return "TCP"
 }
 
-func serverWriter(conn net.Conn, opt Options, c, connections int, isTLS bool, agg *aggregate) {
+func serverWriter(ctx context.Context, conn net.Conn, opt Options, c, connections int, isTLS bool, agg *aggregate) {
 
 	log.Printf("serverWriter: starting: %s %v", protoLabel(isTLS), conn.RemoteAddr())
 
@@ -382,12 +412,12 @@ func serverWriter(conn net.Conn, opt Options, c, connections int, isTLS bool, ag
 
 	buf := randBuf(opt.TCPWriteSize)
 
-	workLoop(connIndex, "serverWriter", "snd/s", conn.Write, buf, opt.ReportInterval, opt.MaxSpeed, nil, agg)
+	workLoop(ctx, connIndex, "serverWriter", "snd/s", conn.Write, buf, opt.ReportInterval, opt.MaxSpeed, nil, agg)
 
 	log.Printf("serverWriter: exiting: %v", conn.RemoteAddr())
 }
 
-func serverWriterTo(conn *net.UDPConn, opt Options, dst net.Addr, acc *account, c, connections int, agg *aggregate) {
+func serverWriterTo(ctx context.Context, conn *net.UDPConn, opt Options, dst net.Addr, acc *account, c, connections int, agg *aggregate) {
 	log.Printf("serverWriterTo: starting: UDP %v", dst)
 
 	start := acc.prevTime
@@ -404,7 +434,7 @@ func serverWriterTo(conn *net.UDPConn, opt Options, dst net.Addr, acc *account, 
 
 	buf := randBuf(opt.UDPWriteSize)
 
-	workLoop(connIndex, "serverWriterTo", "snd/s", udpWriteTo, buf, opt.ReportInterval, opt.MaxSpeed, nil, agg)
+	workLoop(ctx, connIndex, "serverWriterTo", "snd/s", udpWriteTo, buf, opt.ReportInterval, opt.MaxSpeed, nil, agg)
 
 	log.Printf("serverWriterTo: exiting: %v", dst)
 }


### PR DESCRIPTION
Implement graceful shutdown for both server and client modes using context cancellation. The application now properly handles SIGINT and SIGTERM signals, allowing all goroutines to complete cleanup before exit.

Changes:
- Add signal handling for os.Interrupt and syscall.SIGTERM
- Pass context.Context throughout Serve/Open and connection handlers
- Check ctx.Done() in work loops (workLoop, handleTCP, handleUDP)
- Update tests to use context.Background()

<img width="1910" height="1557" alt="image" src="https://github.com/user-attachments/assets/be0e025d-2a22-4a7c-b33c-df5d15adebd6" />
<img width="1377" height="705" alt="image" src="https://github.com/user-attachments/assets/ceafaa11-4eb6-4a93-abf1-5a35e0549918" />

