### PR TITLE
Refactor CLI: migrate from flag to pflag with shorthand support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 **/export*.yaml
+test/output/
 # Binaries for programs and plugins
 *.exe
 *.dll

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ goben is a golang tool to measure TCP/UDP transport layer throughput between hos
 - [Command-line Options](#command-line-options)
 - [Example](#example)
 - [TLS](#tls)
+- [Export](#export)
 
 Created by [gh-md-toc](https://github.com/ekalinin/github-markdown-toc.go)
 
@@ -78,9 +79,9 @@ Usage of goben:
       --ca string               TLS CA certificate file for peer verification (PEM format) (default "ca.pem")
       --cert string             TLS certificate file (PEM format) (default "cert.pem")
   -c, --connections int         number of parallel connections to each host (default 1)
-  -p, --defaultPort int         default port, automatically appended to hosts without explicit port (default 8080)
-  -e, --export int              export mode: 1=ASCII (default), 2=CSV, 3=YAML, 4=PNG (default 1)
-      --exportFile string       output filename for CSV/YAML/PNG export (supports %d=connIndex, %s=host)
+  -p, --defaultPort string      default port, automatically appended to hosts without explicit port (default ":8080")
+  -e, --export strings          export mode: comma-separated or repeated flags of ascii, csv, yaml, png, or filenames
+                                example: --export ascii,csv,result-%d-%s.yaml or -e my.yaml -e my.png
   -H, --hosts strings           comma-separated list of target hosts for client mode
                                 format: host[:port] (port defaults to --defaultPort)
       --key string              TLS private key file (PEM format) (default "key.pem")
@@ -111,81 +112,80 @@ Usage of goben:
 Server side:
 
     $ goben
-    2026/06/10 01:49:33 goben version 1.0.3 runtime go1.26.2 GOMAXPROCS=16 OS=linux arch=amd64
-    2026/06/10 01:49:33 connections=1 defaultPort=8080 listeners=[] hosts=[]
-    2026/06/10 01:49:33 reportInterval=0s totalDuration=0s
-    2026/06/10 01:49:33 server mode (use --hosts to switch to client mode)
-    2026/06/10 01:49:33 listenTCP: TLS disabled
-    2026/06/10 01:49:33 listenTCP: spawning TLS listener: :8080
-    2026/06/10 01:49:33 listenUDP: UDP disabled
+    2026/06/12 00:36:38 goben version 1.1.0 runtime go1.26.4 GOMAXPROCS=16 OS=linux arch=amd64
+    2026/06/12 00:36:38 connections=1 defaultPort=:8080 listeners=[] hosts=[]
+    2026/06/12 00:36:38 reportInterval=0s totalDuration=0s
+    2026/06/12 00:36:38 server mode (use -hosts to switch to client mode)
+    2026/06/12 00:36:38 listenTCP: TLS disabled
+    2026/06/12 00:36:38 listenTCP: spawning TLS listener: :8080
+    2026/06/12 00:36:38 listenUDP: UDP disabled
 
 Client side:
 
     $ goben -H 127.0.0.1
-    2026/06/10 01:49:34 goben version 1.0.3 runtime go1.26.2 GOMAXPROCS=16 OS=linux arch=amd64
-    2026/06/10 01:49:34 connections=1 defaultPort=8080 listeners=[] hosts=["127.0.0.1"]
-    2026/06/10 01:49:34 reportInterval=0s totalDuration=0s
-    2026/06/10 01:49:34 client mode, tcp protocol
-    2026/06/10 01:49:34 open: opening TLS=false tcp 0/1: 127.0.0.1:8080
-    2026/06/10 01:49:34 open: trying non-TLS TCP
-    2026/06/10 01:49:34 handleConnectionClient: starting TCP 0/1 127.0.0.1:8080
-    2026/06/10 01:49:34 handleConnectionClient: options sent: {1s 2s 1000000 1000000 64000 64000 false 0 map[]}
-    2026/06/10 01:49:34 serverVersion=1.0.3
-    2026/06/10 01:49:34 handleConnectionClient: TCP ack received
-    2026/06/10 01:49:34 clientWriter: starting: 0/1 127.0.0.1:8080
-    2026/06/10 01:49:34 clientReader: starting: 0/1 127.0.0.1:8080
-    2026/06/10 01:49:35 0/1  report   clientReader rate: 21994.914328 Mbps   3732 rcv/s
-    2026/06/10 01:49:35 0/1  report   clientWriter rate: 21881.352904 Mbps   2735 snd/s
-    2026/06/10 01:49:36 handleConnectionClient: 2s timer
-    2018/06/28 15:04:28 open: opening tcp 0/1: localhost:8080
-    2018/06/28 15:04:28 handleConnectionClient: starting 0/1 [::1]:8080
-    2018/06/28 15:04:28 handleConnectionClient: options sent: {2s 10s 50000 50000 false 0}
-    2018/06/28 15:04:28 clientReader: starting: 0/1 [::1]:8080
-    2018/06/28 15:04:28 clientWriter: starting: 0/1 [::1]:8080
-    2018/06/28 15:04:30 0/1  report   clientReader rate:  13917 Mbps  34793 rcv/s
-    2018/06/28 15:04:30 0/1  report   clientWriter rate:  13468 Mbps  33670 snd/s
-    2018/06/28 15:04:32 0/1  report   clientReader rate:  14044 Mbps  35111 rcv/s
-    2018/06/28 15:04:32 0/1  report   clientWriter rate:  13591 Mbps  33978 snd/s
-    2018/06/28 15:04:34 0/1  report   clientReader rate:  12934 Mbps  32337 rcv/s
-    2018/06/28 15:04:34 0/1  report   clientWriter rate:  12517 Mbps  31294 snd/s
-    2018/06/28 15:04:36 0/1  report   clientReader rate:  13307 Mbps  33269 rcv/s
-    2018/06/28 15:04:36 0/1  report   clientWriter rate:  12878 Mbps  32196 snd/s
-    2018/06/28 15:04:38 0/1  report   clientWriter rate:  13330 Mbps  33325 snd/s
-    2018/06/28 15:04:38 0/1  report   clientReader rate:  13774 Mbps  34436 rcv/s
-    2018/06/28 15:04:38 handleConnectionClient: 10s timer
-    2018/06/28 15:04:38 workLoop: 0/1 clientWriter: write tcp [::1]:42130->[::1]:8080: use of closed network connection
-    2018/06/28 15:04:38 0/1 average   clientWriter rate:  13157 Mbps  32892 snd/s
-    2018/06/28 15:04:38 clientWriter: exiting: 0/1 [::1]:8080
-    2018/06/28 15:04:38 workLoop: 0/1 clientReader: read tcp [::1]:42130->[::1]:8080: use of closed network connection
-    2018/06/28 15:04:38 0/1 average   clientReader rate:  13595 Mbps  33989 rcv/s
-    2018/06/28 15:04:38 clientReader: exiting: 0/1 [::1]:8080
-    2018/06/28 15:04:38 input:
-     14038 ┤          ╭────╮
-     13939 ┤──────────╯    ╰╮
-     13840 ┼                ╰─╮
-     13741 ┤                  ╰╮                                    ╭──
-     13641 ┤                   ╰╮                               ╭───╯
-     13542 ┤                    ╰─╮                          ╭──╯
-     13443 ┤                      ╰╮                     ╭───╯
-     13344 ┤                       ╰─╮               ╭───╯
-     13245 ┤                         ╰╮          ╭───╯
-     13146 ┤                          ╰─╮    ╭───╯
-     13047 ┤                            ╰────╯
-     12948 ┤
-    2018/06/28 15:04:38 output:
-     13585 ┤          ╭────╮
-     13489 ┤──────────╯    ╰╮
-     13393 ┼                ╰─╮
-     13297 ┤                  ╰╮                                    ╭──
-     13201 ┤                   ╰╮                               ╭───╯
-     13105 ┤                    ╰─╮                          ╭──╯
-     13009 ┤                      ╰╮                     ╭───╯
-     12914 ┤                       ╰─╮               ╭───╯
-     12818 ┤                         ╰╮          ╭───╯
-     12722 ┤                          ╰─╮    ╭───╯
-     12626 ┤                            ╰────╯
-     12530 ┤
-    2018/06/28 15:04:38 handleConnectionClient: closing: 0/1 [::1]:8080
+    2026/06/12 00:36:39 goben version 1.1.0 runtime go1.26.4 GOMAXPROCS=16 OS=linux arch=amd64
+    2026/06/12 00:36:39 connections=1 defaultPort=:8080 listeners=[] hosts=["127.0.0.1"]
+    2026/06/12 00:36:39 reportInterval=0s totalDuration=0s
+    2026/06/12 00:36:39 client mode, tcp protocol
+    2026/06/12 00:36:39 open: opening TLS=false tcp 0/1: 127.0.0.1:8080
+    2026/06/12 00:36:39 open: trying non-TLS TCP
+    2026/06/12 00:36:39 handleConnectionClient: starting TCP 0/1 127.0.0.1:8080
+    2026/06/12 00:36:39 handleConnectionClient: options sent: {1s 2s 1000000 1000000 64000 64000 false 0 map[]}
+    2026/06/12 00:36:39 serverVersion=1.1.0
+    2026/06/12 00:36:39 handleConnectionClient: TCP ack received
+    2026/06/12 00:36:39 clientWriter: starting: 0/1 127.0.0.1:8080
+    2026/06/12 00:36:39 clientReader: starting: 0/1 127.0.0.1:8080
+    2026/06/12 00:36:40 0/1  report   clientReader rate: 21467.668538 Mbps   3503 rcv/s
+    2026/06/12 00:36:40 0/1  report   clientWriter rate: 21837.537818 Mbps   2729 snd/s
+    2026/06/12 00:36:41 handleConnectionClient: 2s timer
+    2026/06/12 00:36:41 127.0.0.1:8080 input:
+     21468 ┼─────────────────────────╮
+     19321 ┤                         ╰───────────╮
+     17174 ┤                                     ╰───╮
+     15027 ┤                                         ╰──╮
+     12881 ┤                                            ╰───╮
+     10734 ┤                                                ╰───╮
+      8587 ┤                                                    ╰───╮
+      6440 ┤                                                        ╰──╮
+      4294 ┤                                                           ╰───╮
+      2147 ┤                                                               ╰───╮
+         0 ┤                                                                   ╰─
+                       Input Mbps: 127.0.0.1:8080 Connection 0
+    2026/06/12 00:36:41 127.0.0.1:8080 output:
+     21838 ┼──────╮
+     21704 ┤      ╰──────╮
+     21570 ┤             ╰──────╮
+     21437 ┤                    ╰──────╮
+     21303 ┤                           ╰──────╮
+     21170 ┤                                  ╰──────╮
+     21036 ┤                                         ╰──────╮
+     20903 ┤                                                ╰──────╮
+     20769 ┤                                                       ╰──────╮
+     20635 ┤                                                              ╰─────╮
+     20502 ┤                                                                    ╰
+                       Output Mbps: 127.0.0.1:8080 Connection 0
+    2026/06/12 00:36:41 handleConnectionClient: closing: 0/1 127.0.0.1:8080
+    2026/06/12 00:36:41 aggregate reading: 20748.578718 Mbps 3006 recv/s
+    2026/06/12 00:36:41 aggregate writing: 21170.406833 Mbps 2646 send/s
+
+# Export
+
+Use `-e` / `--export` to save test results in one or more formats. Supported formats: `ascii`, `csv`, `yaml`, `png`.
+
+Multiple formats can be combined with commas or repeated flags:
+
+    # export CSV and YAML with auto-generated filenames
+    goben -H 1.1.1.1 -e csv,yaml
+
+    # export to specific filenames (extension determines format)
+    goben -H 1.1.1.1 -e result.csv -e report.yaml
+
+    # short form with multiple flags
+    goben -H 1.1.1.1 -e ascii -e png
+
+Without `--export`, ASCII charts are printed to the console only. Passing `--export ascii` also writes the chart to a file.
+
+Auto-generated filenames use the pattern `result-<connIndex>-<host>.<ext>` (e.g. `result-0-127.0.0.1.csv`).
 
 # TLS
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Start server:
 
 Start client:
 
-    client$ goben -hosts 1.1.1.1 ;# 1.1.1.1 is server's address
+    client$ goben -H 1.1.1.1 ;# 1.1.1.1 is server's address
 
 # Command-line Options
 
@@ -74,74 +74,36 @@ Find several supported command-line switches by running 'goben -h':
 
 ```
 $ goben -h
-2021/02/28 00:43:28 goben version 0.6 runtime go1.16 GOMAXPROCS=12 OS=linux arch=amd64
 Usage of goben:
-  -ascii
-        plot ascii chart (default true)
-  -ca string
-        TLS CA file (if server: CA to validate the client cert, if client: CA to validate the server cert) (default "ca.pem")
-  -cert string
-        TLS cert file (default "cert.pem")
-  -chart string
-        output filename for rendering chart on client
-        '%d' is parallel connection index to host
-        '%s' is hostname:port
-        example: -chart chart-%d-%s.png
-  -connections int
-        number of parallel connections (default 1)
-  -csv string
-        output filename for CSV exporting test results on client
-        '%d' is parallel connection index to host
-        '%s' is hostname:port
-        example: -csv export-%d-%s.csv
-  -defaultPort string
-        default port (default ":8080")
-  -export string
-        output filename for YAML exporting test results on client
-        '%d' is parallel connection index to host
-        '%s' is hostname:port
-        example: -export export-%d-%s.yaml
-  -hosts value
-        comma-separated list of hosts
-        you may append an optional port to every host: host[:port]
-  -key string
-        TLS key file (default "key.pem")
-  -listeners value
-        comma-separated list of listen addresses
-        you may prepend an optional host to every port: [host]:port
-  -localAddr string
-        bind specific local address:port
-        example: -localAddr 127.0.0.1:2000
-  -maxSpeed float
-        bandwidth limit in mbps (0 means unlimited)
-  -passiveClient
-        suppress client writes
-  -passiveServer
-        suppress server writes
-  -reportInterval string
-        periodic report interval
-        unspecified time unit defaults to second (default "2s")
-  -tcp
-        set to false to disable TCP (this can be used to test TLS only or UDP only) (default true)
-  -tcpReadSize int
-        TCP read buffer size in bytes (default 1000000)
-  -tcpWriteSize int
-        TCP write buffer size in bytes (default 1000000)
-  -tls
-        set to false to disable TLS (default true)
-  -tlsAuthClient
-        set to true to enable client certificate authentication (check against CA) (default true)
-  -tlsAuthServer
-        set to true to enable server certificate authentication (check against CA) (default true)
-  -totalDuration string
-        test total duration
-        unspecified time unit defaults to second (default "10s")
-  -udp
-        run client in UDP mode
-  -udpReadSize int
-        UDP read buffer size in bytes (default 64000)
-  -udpWriteSize int
-        UDP write buffer size in bytes (default 64000)
+      --ca string               TLS CA certificate file for peer verification (PEM format) (default "ca.pem")
+      --cert string             TLS certificate file (PEM format) (default "cert.pem")
+  -c, --connections int         number of parallel connections to each host (default 1)
+  -p, --defaultPort int         default port, automatically appended to hosts without explicit port (default 8080)
+  -e, --export int              export mode: 1=ASCII (default), 2=CSV, 3=YAML, 4=PNG (default 1)
+      --exportFile string       output filename for CSV/YAML/PNG export (supports %d=connIndex, %s=host)
+  -H, --hosts strings           comma-separated list of target hosts for client mode
+                                format: host[:port] (port defaults to --defaultPort)
+      --key string              TLS private key file (PEM format) (default "key.pem")
+  -l, --listeners strings       comma-separated list of listen addresses for server mode
+                                format: [host]:port
+  -a, --localAddr string        bind specific local address:port
+                                example: --localAddr 127.0.0.1:2000
+  -m, --maxSpeed float          bandwidth limit in Mbps (0 means unlimited)
+      --passiveClient           suppress client traffic (receive only)
+      --passiveServer           suppress server traffic (receive only)
+  -i, --reportInterval string   periodic throughput report interval
+                                unspecified time unit defaults to second (default "2s")
+  -t, --tcp                     enable TCP transport (disable to test TLS-only or UDP-only) (default true)
+      --tcpReadSize int         TCP read buffer size in bytes (default 1000000)
+      --tcpWriteSize int        TCP write buffer size in bytes (default 1000000)
+  -s, --tls                     enable TLS encryption (default true)
+      --tlsAuthClient           enable mutual TLS: verify server certificate against CA (default true)
+      --tlsAuthServer           enable mutual TLS: verify client certificate against CA (default true)
+  -d, --totalDuration string    total test duration
+                                unspecified time unit defaults to second (default "10s")
+  -u, --udp                     use UDP protocol instead of TCP
+      --udpReadSize int         UDP read buffer size in bytes (default 64000)
+      --udpWriteSize int        UDP write buffer size in bytes (default 64000)
 ```
 
 # Example
@@ -149,20 +111,32 @@ Usage of goben:
 Server side:
 
     $ goben
-    2018/06/28 15:04:26 goben version 0.3 runtime go1.11beta1 GOMAXPROCS=1
-    2018/06/28 15:04:26 connections=1 defaultPort=:8080 listeners=[":8080"] hosts=[]
-    2018/06/28 15:04:26 reportInterval=2s totalDuration=10s
-    2018/06/28 15:04:26 server mode (use -hosts to switch to client mode)
-    2018/06/28 15:04:26 serve: spawning TCP listener: :8080
-    2018/06/28 15:04:26 serve: spawning UDP listener: :8080
+    2026/06/10 01:49:33 goben version 1.0.3 runtime go1.26.2 GOMAXPROCS=16 OS=linux arch=amd64
+    2026/06/10 01:49:33 connections=1 defaultPort=8080 listeners=[] hosts=[]
+    2026/06/10 01:49:33 reportInterval=0s totalDuration=0s
+    2026/06/10 01:49:33 server mode (use --hosts to switch to client mode)
+    2026/06/10 01:49:33 listenTCP: TLS disabled
+    2026/06/10 01:49:33 listenTCP: spawning TLS listener: :8080
+    2026/06/10 01:49:33 listenUDP: UDP disabled
 
 Client side:
 
-    $ goben -hosts localhost
-    2018/06/28 15:04:28 goben version 0.3 runtime go1.11beta1 GOMAXPROCS=1
-    2018/06/28 15:04:28 connections=1 defaultPort=:8080 listeners=[":8080"] hosts=["localhost"]
-    2018/06/28 15:04:28 reportInterval=2s totalDuration=10s
-    2018/06/28 15:04:28 client mode, tcp protocol
+    $ goben -H 127.0.0.1
+    2026/06/10 01:49:34 goben version 1.0.3 runtime go1.26.2 GOMAXPROCS=16 OS=linux arch=amd64
+    2026/06/10 01:49:34 connections=1 defaultPort=8080 listeners=[] hosts=["127.0.0.1"]
+    2026/06/10 01:49:34 reportInterval=0s totalDuration=0s
+    2026/06/10 01:49:34 client mode, tcp protocol
+    2026/06/10 01:49:34 open: opening TLS=false tcp 0/1: 127.0.0.1:8080
+    2026/06/10 01:49:34 open: trying non-TLS TCP
+    2026/06/10 01:49:34 handleConnectionClient: starting TCP 0/1 127.0.0.1:8080
+    2026/06/10 01:49:34 handleConnectionClient: options sent: {1s 2s 1000000 1000000 64000 64000 false 0 map[]}
+    2026/06/10 01:49:34 serverVersion=1.0.3
+    2026/06/10 01:49:34 handleConnectionClient: TCP ack received
+    2026/06/10 01:49:34 clientWriter: starting: 0/1 127.0.0.1:8080
+    2026/06/10 01:49:34 clientReader: starting: 0/1 127.0.0.1:8080
+    2026/06/10 01:49:35 0/1  report   clientReader rate: 21994.914328 Mbps   3732 rcv/s
+    2026/06/10 01:49:35 0/1  report   clientWriter rate: 21881.352904 Mbps   2735 snd/s
+    2026/06/10 01:49:36 handleConnectionClient: 2s timer
     2018/06/28 15:04:28 open: opening tcp 0/1: localhost:8080
     2018/06/28 15:04:28 handleConnectionClient: starting 0/1 [::1]:8080
     2018/06/28 15:04:28 handleConnectionClient: options sent: {2s 10s 50000 50000 false 0}

--- a/cmd/goben/main.go
+++ b/cmd/goben/main.go
@@ -3,7 +3,6 @@ package main
 
 import (
 	"context"
-	"flag"
 	"log"
 	"os"
 	"os/signal"
@@ -12,6 +11,8 @@ import (
 	"sync"
 	"syscall"
 
+	"github.com/spf13/pflag"
+
 	"github.com/udhos/goben/goben"
 )
 
@@ -19,8 +20,8 @@ func main() {
 
 	app := goben.Config{}
 
-	app.AssignFlags(flag.CommandLine)
-	flag.Parse()
+	app.AssignFlags(pflag.CommandLine)
+	pflag.Parse()
 
 	log.Print("goben version " + goben.Version + " runtime " + runtime.Version() + " GOMAXPROCS=" + strconv.Itoa(runtime.GOMAXPROCS(0)) + " OS=" + runtime.GOOS + " arch=" + runtime.GOARCH)
 	log.Printf("connections=%d defaultPort=%s listeners=%q hosts=%q",

--- a/cmd/goben/main_test.go
+++ b/cmd/goben/main_test.go
@@ -37,7 +37,8 @@ func TestEndToEndInvalidTLSConfig(t *testing.T) {
 	client.TLS = true
 	client.TCP = false
 	client.UDP = false
-	client.Export = "export-%d-%s.yaml"
+	client.ExportMode = goben.ExportYAML
+	client.ExportFile = "export-%d-%s.yaml"
 	client.ReportInterval = "1s"
 	client.TotalDuration = "2s"
 	client.Connections = 1

--- a/cmd/goben/main_test.go
+++ b/cmd/goben/main_test.go
@@ -37,8 +37,7 @@ func TestEndToEndInvalidTLSConfig(t *testing.T) {
 	client.TLS = true
 	client.TCP = false
 	client.UDP = false
-	client.ExportMode = goben.ExportYAML
-	client.ExportFile = "export-%d-%s.yaml"
+	client.Export = []string{"export-%d-%s.yaml"}
 	client.ReportInterval = "1s"
 	client.TotalDuration = "2s"
 	client.Connections = 1

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,7 @@ module github.com/udhos/goben
 
 require (
 	github.com/guptarohit/asciigraph v0.9.0
+	github.com/spf13/pflag v1.0.10
 	github.com/stretchr/testify v1.9.0
 	github.com/wcharczuk/go-chart v2.0.1+incompatible
 	gopkg.in/yaml.v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -16,6 +16,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rogpeppe/go-internal v1.9.0 h1:73kH8U+JUqXU8lRuOHeVHaa/SZPifC7BkcraZVejAe8=
 github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
+github.com/spf13/pflag v1.0.10 h1:4EBh2KAYBwaONj6b2Ye1GiHfwjqyROoF4RwYO+vPwFk=
+github.com/spf13/pflag v1.0.10/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/wcharczuk/go-chart v2.0.1+incompatible h1:0pz39ZAycJFF7ju/1mepnk26RLVLBCWz1STcD3doU0A=

--- a/goben/client.go
+++ b/goben/client.go
@@ -254,7 +254,7 @@ func handleConnectionClient(ctx context.Context, app *Config, wg *sync.WaitGroup
 	var input *ChartData
 	var output *ChartData
 
-	if app.CSV != "" || app.Export != "" || app.Chart != "" || app.ASCII {
+	if app.ExportMode > 0 {
 		input = &info.Input
 		output = &info.Output
 	}
@@ -284,9 +284,8 @@ func handleConnectionClient(ctx context.Context, app *Config, wg *sync.WaitGroup
 		<-doneWriter
 	}
 
-	if app.CSV != "" {
-
-		filename := fmt.Sprintf(app.CSV, c, formatAddress(conn))
+	if app.ExportMode == ExportCSV && app.ExportFile != "" {
+		filename := fmt.Sprintf(app.ExportFile, c, formatAddress(conn))
 		log.Printf("exporting CSV test results to: %s", filename)
 		errExport := exportCsv(filename, &info)
 		if errExport != nil {
@@ -294,8 +293,8 @@ func handleConnectionClient(ctx context.Context, app *Config, wg *sync.WaitGroup
 		}
 	}
 
-	if app.Export != "" {
-		filename := fmt.Sprintf(app.Export, c, formatAddress(conn))
+	if app.ExportMode == ExportYAML && app.ExportFile != "" {
+		filename := fmt.Sprintf(app.ExportFile, c, formatAddress(conn))
 		log.Printf("exporting YAML test results to: %s", filename)
 		errExport := export(filename, &info)
 		if errExport != nil {
@@ -303,8 +302,8 @@ func handleConnectionClient(ctx context.Context, app *Config, wg *sync.WaitGroup
 		}
 	}
 
-	if app.Chart != "" {
-		filename := fmt.Sprintf(app.Chart, c, formatAddress(conn))
+	if app.ExportMode == ExportPNG && app.ExportFile != "" {
+		filename := fmt.Sprintf(app.ExportFile, c, formatAddress(conn))
 		log.Printf("rendering chart to: %s", filename)
 		errRender := chartRender(filename, &info.Input, &info.Output)
 		if errRender != nil {
@@ -312,7 +311,7 @@ func handleConnectionClient(ctx context.Context, app *Config, wg *sync.WaitGroup
 		}
 	}
 
-	if app.ASCII {
+	if app.ExportMode == ExportASCII {
 		plotascii(&info, conn.RemoteAddr().String(), c)
 	}
 

--- a/goben/client.go
+++ b/goben/client.go
@@ -254,7 +254,7 @@ func handleConnectionClient(ctx context.Context, app *Config, wg *sync.WaitGroup
 	var input *ChartData
 	var output *ChartData
 
-	if app.ExportMode > 0 {
+	if len(app.exports) > 0 {
 		input = &info.Input
 		output = &info.Output
 	}
@@ -277,6 +277,7 @@ func handleConnectionClient(ctx context.Context, app *Config, wg *sync.WaitGroup
 
 	tickerPeriod.Stop()
 
+	remoteAddr := formatAddress(conn)
 	conn.Close()
 
 	<-doneReader
@@ -284,38 +285,49 @@ func handleConnectionClient(ctx context.Context, app *Config, wg *sync.WaitGroup
 		<-doneWriter
 	}
 
-	if app.ExportMode == ExportCSV && app.ExportFile != "" {
-		filename := fmt.Sprintf(app.ExportFile, c, formatAddress(conn))
-		log.Printf("exporting CSV test results to: %s", filename)
-		errExport := exportCsv(filename, &info)
-		if errExport != nil {
-			log.Printf("handleConnectionClient: export CSV: %s: %v", filename, errExport)
+	for _, t := range app.exports {
+		var filename string
+		if t.Filename != "" {
+			if strings.Contains(t.Filename, "%") {
+				filename = fmt.Sprintf(t.Filename, c, remoteAddr)
+			} else {
+				filename = t.Filename
+			}
+		}
+		switch t.Mode {
+		case "ascii":
+			if filename != "" {
+				log.Printf("exporting ASCII test results to: %s", filename)
+			}
+			plotasciiToFile(filename, &info, remoteAddr, c)
+		case "csv":
+			if filename == "" {
+				continue
+			}
+			log.Printf("exporting CSV test results to: %s", filename)
+			if errExport := exportCsv(filename, &info); errExport != nil {
+				log.Printf("handleConnectionClient: export CSV: %s: %v", filename, errExport)
+			}
+		case "yaml":
+			if filename == "" {
+				continue
+			}
+			log.Printf("exporting YAML test results to: %s", filename)
+			if errExport := export(filename, &info); errExport != nil {
+				log.Printf("handleConnectionClient: export YAML: %s: %v", filename, errExport)
+			}
+		case "png":
+			if filename == "" {
+				continue
+			}
+			log.Printf("rendering chart to: %s", filename)
+			if errRender := chartRender(filename, &info.Input, &info.Output); errRender != nil {
+				log.Printf("handleConnectionClient: render PNG: %s: %v", filename, errRender)
+			}
 		}
 	}
 
-	if app.ExportMode == ExportYAML && app.ExportFile != "" {
-		filename := fmt.Sprintf(app.ExportFile, c, formatAddress(conn))
-		log.Printf("exporting YAML test results to: %s", filename)
-		errExport := export(filename, &info)
-		if errExport != nil {
-			log.Printf("handleConnectionClient: export YAML: %s: %v", filename, errExport)
-		}
-	}
-
-	if app.ExportMode == ExportPNG && app.ExportFile != "" {
-		filename := fmt.Sprintf(app.ExportFile, c, formatAddress(conn))
-		log.Printf("rendering chart to: %s", filename)
-		errRender := chartRender(filename, &info.Input, &info.Output)
-		if errRender != nil {
-			log.Printf("handleConnectionClient: render PNG: %s: %v", filename, errRender)
-		}
-	}
-
-	if app.ExportMode == ExportASCII {
-		plotascii(&info, conn.RemoteAddr().String(), c)
-	}
-
-	log.Printf("handleConnectionClient: closing: %d/%d %v", c, connections, conn.RemoteAddr())
+	log.Printf("handleConnectionClient: closing: %d/%d %v", c, connections, remoteAddr)
 }
 
 func getBufSize(opt Options, isUDP bool) (bufSizeIn int, bufSizeOut int) {

--- a/goben/config.go
+++ b/goben/config.go
@@ -1,12 +1,13 @@
 package goben
 
 import (
-	"flag"
 	"fmt"
 	"log"
 	"strings"
 	"time"
 	"unicode"
+
+	"github.com/spf13/pflag"
 )
 
 // Version is the current application version.
@@ -14,6 +15,15 @@ const Version = "1.1.0"
 
 // HostList holds a list of hosts to connect to or listen on.
 type HostList []string
+
+// Export modes
+const (
+	ExportNone  = 0
+	ExportASCII = 1
+	ExportCSV   = 2
+	ExportYAML  = 3
+	ExportPNG   = 4
+)
 
 // Config holds the configuration for the client and server.
 type Config struct {
@@ -24,12 +34,10 @@ type Config struct {
 	ReportInterval string
 	TotalDuration  string
 	Opt            Options
-	PassiveClient  bool // suppress client send
+	PassiveClient  bool
 	UDP            bool
-	Chart          string
-	Export         string
-	CSV            string
-	ASCII          bool // plot ascii chart
+	ExportMode     int
+	ExportFile     string
 	TLSCert        string
 	TLSKey         string
 	TLSCA          string
@@ -41,33 +49,31 @@ type Config struct {
 }
 
 // AssignFlags parses command line flags.
-func (app *Config) AssignFlags(flagset *flag.FlagSet) {
-	flagset.Var(&app.Hosts, "hosts", "comma-separated list of hosts\nyou may append an optional port to every host: host[:port]")
-	flagset.Var(&app.Listeners, "listeners", "comma-separated list of listen addresses\nyou may prepend an optional host to every port: [host]:port")
-	flagset.StringVar(&app.DefaultPort, "defaultPort", ":8080", "default port")
-	flagset.IntVar(&app.Connections, "connections", 1, "number of parallel connections")
-	flagset.StringVar(&app.ReportInterval, "reportInterval", "2s", "periodic report interval\nunspecified time unit defaults to second")
-	flagset.StringVar(&app.TotalDuration, "totalDuration", "10s", "test total duration\nunspecified time unit defaults to second")
+func (app *Config) AssignFlags(flagset *pflag.FlagSet) {
+	flagset.VarP(&app.Hosts, "hosts", "H", "comma-separated list of target hosts for client mode\nformat: host[:port] (port defaults to --defaultPort)")
+	flagset.VarP(&app.Listeners, "listeners", "l", "comma-separated list of listen addresses for server mode\nformat: [host]:port")
+	flagset.StringVarP(&app.DefaultPort, "defaultPort", "p", ":8080", "default port, automatically appended to hosts without explicit port")
+	flagset.IntVarP(&app.Connections, "connections", "c", 1, "number of parallel connections to each host")
+	flagset.StringVarP(&app.ReportInterval, "reportInterval", "i", "2s", "periodic throughput report interval\nunspecified time unit defaults to second")
+	flagset.StringVarP(&app.TotalDuration, "totalDuration", "d", "10s", "total test duration\nunspecified time unit defaults to second")
 	flagset.IntVar(&app.Opt.TCPReadSize, "tcpReadSize", 1000000, "TCP read buffer size in bytes")
 	flagset.IntVar(&app.Opt.TCPWriteSize, "tcpWriteSize", 1000000, "TCP write buffer size in bytes")
 	flagset.IntVar(&app.Opt.UDPReadSize, "udpReadSize", 64000, "UDP read buffer size in bytes")
 	flagset.IntVar(&app.Opt.UDPWriteSize, "udpWriteSize", 64000, "UDP write buffer size in bytes")
-	flagset.BoolVar(&app.PassiveClient, "passiveClient", false, "suppress client writes")
-	flagset.BoolVar(&app.Opt.PassiveServer, "passiveServer", false, "suppress server writes")
-	flagset.Float64Var(&app.Opt.MaxSpeed, "maxSpeed", 0, "bandwidth limit in mbps (0 means unlimited)")
-	flagset.BoolVar(&app.UDP, "udp", false, "run client in UDP mode")
-	flagset.StringVar(&app.Chart, "chart", "", "output filename for rendering chart on client\n'%d' is parallel connection index to host\n'%s' is hostname:port\nexample: -chart chart-%d-%s.png")
-	flagset.StringVar(&app.Export, "export", "", "output filename for YAML exporting test results on client\n'%d' is parallel connection index to host\n'%s' is hostname:port\nexample: -export export-%d-%s.yaml")
-	flagset.StringVar(&app.CSV, "csv", "", "output filename for CSV exporting test results on client\n'%d' is parallel connection index to host\n'%s' is hostname:port\nexample: -csv export-%d-%s.csv")
-	flagset.BoolVar(&app.ASCII, "ascii", true, "plot ascii chart")
-	flagset.StringVar(&app.TLSKey, "key", "key.pem", "TLS key file")
-	flagset.StringVar(&app.TLSCert, "cert", "cert.pem", "TLS cert file")
-	flagset.StringVar(&app.TLSCA, "ca", "ca.pem", "TLS CA file (if server: CA to validate the client cert, if client: CA to validate the server cert)")
-	flagset.BoolVar(&app.TLS, "tls", true, "set to false to disable TLS")
-	flagset.BoolVar(&app.TLSAuthClient, "tlsAuthClient", true, "set to true to enable client certificate authentication (check against CA)")
-	flagset.BoolVar(&app.TLSAuthServer, "tlsAuthServer", true, "set to true to enable server certificate authentication (check against CA)")
-	flagset.BoolVar(&app.TCP, "tcp", true, "set to false to disable TCP (this can be used to test TLS only or UDP only)")
-	flagset.StringVar(&app.LocalAddr, "localAddr", "", "bind specific local address:port\nexample: -localAddr 127.0.0.1:2000")
+	flagset.BoolVar(&app.PassiveClient, "passiveClient", false, "suppress client traffic (receive only)")
+	flagset.BoolVar(&app.Opt.PassiveServer, "passiveServer", false, "suppress server traffic (receive only)")
+	flagset.Float64VarP(&app.Opt.MaxSpeed, "maxSpeed", "m", 0, "bandwidth limit in Mbps (0 means unlimited)")
+	flagset.BoolVarP(&app.UDP, "udp", "u", false, "use UDP protocol instead of TCP")
+	flagset.IntVarP(&app.ExportMode, "export", "e", ExportNone, "export mode: 0=none, 1=ASCII, 2=CSV, 3=YAML, 4=PNG")
+	flagset.StringVar(&app.ExportFile, "exportFile", "", "output filename for CSV/YAML/PNG export (supports %d=connIndex, %s=host)")
+	flagset.StringVar(&app.TLSKey, "key", "key.pem", "TLS private key file (PEM format)")
+	flagset.StringVar(&app.TLSCert, "cert", "cert.pem", "TLS certificate file (PEM format)")
+	flagset.StringVar(&app.TLSCA, "ca", "ca.pem", "TLS CA certificate file for peer verification (PEM format)")
+	flagset.BoolVarP(&app.TLS, "tls", "s", true, "enable TLS encryption")
+	flagset.BoolVar(&app.TLSAuthClient, "tlsAuthClient", true, "enable mutual TLS: verify server certificate against CA")
+	flagset.BoolVar(&app.TLSAuthServer, "tlsAuthServer", true, "enable mutual TLS: verify client certificate against CA")
+	flagset.BoolVarP(&app.TCP, "tcp", "t", true, "enable TCP transport (disable to test TLS-only or UDP-only)")
+	flagset.StringVarP(&app.LocalAddr, "localAddr", "a", "", "bind specific local address:port\nexample: --localAddr 127.0.0.1:2000")
 }
 
 // NewDefaultConfig creates a config with default values
@@ -77,14 +83,14 @@ func NewDefaultConfig() *Config {
 		"clientVersion": Version,
 	}
 
-	flagSet := flag.FlagSet{}
-	result.AssignFlags(&flagSet)
+	flagSet := pflag.NewFlagSet("", pflag.ContinueOnError)
+	result.AssignFlags(flagSet)
 	_ = flagSet.Parse([]string{})
 	return &result
 }
 
 func (h *HostList) String() string {
-	return fmt.Sprint(*h)
+	return strings.Join(*h, ",")
 }
 
 // Set sets HostList value from a comma-separated list.
@@ -93,6 +99,11 @@ func (h *HostList) Set(value string) error {
 		*h = append(*h, hh)
 	}
 	return nil
+}
+
+// Type returns the type name for pflag display.
+func (h *HostList) Type() string {
+	return "strings"
 }
 
 func badExportFilename(parameter, filename string) error {
@@ -110,19 +121,16 @@ func badExportFilename(parameter, filename string) error {
 // ValidateAndUpdateConfig validates and updates the config
 // it will set internal values necessary for successful completion
 func ValidateAndUpdateConfig(app *Config) error {
-	if errChart := badExportFilename("-chart", app.Chart); errChart != nil {
-		log.Printf("%s", errChart.Error())
-		return errChart
+	if app.ExportMode < ExportNone || app.ExportMode > ExportPNG {
+		return fmt.Errorf("invalid export mode %d: must be %d (none), %d (ASCII), %d (CSV), %d (YAML), or %d (PNG)",
+			app.ExportMode, ExportNone, ExportASCII, ExportCSV, ExportYAML, ExportPNG)
 	}
 
-	if errExport := badExportFilename("-export", app.Export); errExport != nil {
-		log.Printf("%s", errExport.Error())
-		return errExport
-	}
-
-	if errCsv := badExportFilename("-csv", app.CSV); errCsv != nil {
-		log.Printf("%s", errCsv.Error())
-		return errCsv
+	if app.ExportMode != ExportASCII && app.ExportFile != "" {
+		if err := badExportFilename("--exportFile", app.ExportFile); err != nil {
+			log.Printf("%s", err.Error())
+			return err
+		}
 	}
 
 	app.ReportInterval = defaultTimeUnit(app.ReportInterval)

--- a/goben/config.go
+++ b/goben/config.go
@@ -3,6 +3,7 @@ package goben
 import (
 	"fmt"
 	"log"
+	"regexp"
 	"strings"
 	"time"
 	"unicode"
@@ -16,14 +17,67 @@ const Version = "1.1.0"
 // HostList holds a list of hosts to connect to or listen on.
 type HostList []string
 
-// Export modes
-const (
-	ExportNone  = 0
-	ExportASCII = 1
-	ExportCSV   = 2
-	ExportYAML  = 3
-	ExportPNG   = 4
+var (
+	reExportMode = regexp.MustCompile(`^(?i)(ascii|csv|yaml|png)$`)
+	reExportExt  = regexp.MustCompile(`(?i)\.(csv|yaml|yml|png|ascii)$`)
 )
+
+// ExportTarget holds an export mode and its output filename.
+type ExportTarget struct {
+	Mode     string
+	Filename string
+}
+
+func defaultExportFilename(mode string) string {
+	return fmt.Sprintf("result-%%d-%%s.%s", mode)
+}
+
+func parseExport(items []string) ([]ExportTarget, error) {
+	if len(items) == 0 {
+		return []ExportTarget{{Mode: "ascii", Filename: ""}}, nil
+	}
+
+	targets := make([]ExportTarget, 0, len(items))
+
+	for _, item := range items {
+		item = strings.TrimSpace(item)
+		if item == "" {
+			continue
+		}
+
+		lower := strings.ToLower(item)
+
+		if reExportMode.MatchString(lower) {
+			mode := lower
+			targets = append(targets, ExportTarget{
+				Mode:     mode,
+				Filename: defaultExportFilename(mode),
+			})
+			continue
+		}
+
+		extMatch := reExportExt.FindStringSubmatch(lower)
+		if extMatch != nil {
+			ext := strings.TrimPrefix(extMatch[0], ".")
+			mode := ext
+			if mode == "yml" {
+				mode = "yaml"
+			}
+			targets = append(targets, ExportTarget{
+				Mode:     mode,
+				Filename: item,
+			})
+			continue
+		}
+
+		return nil, fmt.Errorf("unrecognized export item: %q (expected ascii, csv, yaml, png, or a filename ending in .csv, .yaml, .yml, .png, .ascii)", item)
+	}
+
+	if len(targets) == 0 {
+		return nil, nil
+	}
+	return targets, nil
+}
 
 // Config holds the configuration for the client and server.
 type Config struct {
@@ -36,8 +90,8 @@ type Config struct {
 	Opt            Options
 	PassiveClient  bool
 	UDP            bool
-	ExportMode     int
-	ExportFile     string
+	Export         []string
+	exports        []ExportTarget
 	TLSCert        string
 	TLSKey         string
 	TLSCA          string
@@ -64,8 +118,7 @@ func (app *Config) AssignFlags(flagset *pflag.FlagSet) {
 	flagset.BoolVar(&app.Opt.PassiveServer, "passiveServer", false, "suppress server traffic (receive only)")
 	flagset.Float64VarP(&app.Opt.MaxSpeed, "maxSpeed", "m", 0, "bandwidth limit in Mbps (0 means unlimited)")
 	flagset.BoolVarP(&app.UDP, "udp", "u", false, "use UDP protocol instead of TCP")
-	flagset.IntVarP(&app.ExportMode, "export", "e", ExportNone, "export mode: 0=none, 1=ASCII, 2=CSV, 3=YAML, 4=PNG")
-	flagset.StringVar(&app.ExportFile, "exportFile", "", "output filename for CSV/YAML/PNG export (supports %d=connIndex, %s=host)")
+	flagset.StringSliceVarP(&app.Export, "export", "e", nil, "export mode: comma-separated or repeated flags of ascii, csv, yaml, png, or filenames with recognized extensions\nexample: --export ascii,csv,result-%d-%s.yaml or -e my.yaml -e my.png")
 	flagset.StringVar(&app.TLSKey, "key", "key.pem", "TLS private key file (PEM format)")
 	flagset.StringVar(&app.TLSCert, "cert", "cert.pem", "TLS certificate file (PEM format)")
 	flagset.StringVar(&app.TLSCA, "ca", "ca.pem", "TLS CA certificate file for peer verification (PEM format)")
@@ -121,17 +174,19 @@ func badExportFilename(parameter, filename string) error {
 // ValidateAndUpdateConfig validates and updates the config
 // it will set internal values necessary for successful completion
 func ValidateAndUpdateConfig(app *Config) error {
-	if app.ExportMode < ExportNone || app.ExportMode > ExportPNG {
-		return fmt.Errorf("invalid export mode %d: must be %d (none), %d (ASCII), %d (CSV), %d (YAML), or %d (PNG)",
-			app.ExportMode, ExportNone, ExportASCII, ExportCSV, ExportYAML, ExportPNG)
+	targets, errParse := parseExport(app.Export)
+	if errParse != nil {
+		return fmt.Errorf("invalid --export value: %w", errParse)
 	}
-
-	if app.ExportMode != ExportASCII && app.ExportFile != "" {
-		if err := badExportFilename("--exportFile", app.ExportFile); err != nil {
-			log.Printf("%s", err.Error())
-			return err
+	for _, t := range targets {
+		if strings.Contains(t.Filename, "%") {
+			if err := badExportFilename("--export", t.Filename); err != nil {
+				log.Printf("%s", err.Error())
+				return err
+			}
 		}
 	}
+	app.exports = targets
 
 	app.ReportInterval = defaultTimeUnit(app.ReportInterval)
 	app.TotalDuration = defaultTimeUnit(app.TotalDuration)

--- a/goben/plotascii.go
+++ b/goben/plotascii.go
@@ -3,20 +3,24 @@ package goben
 import (
 	"fmt"
 	"log"
+	"os"
 
 	"github.com/guptarohit/asciigraph"
 )
 
-func plotascii(info *ExportInfo, remote string, index int) {
+func plotasciiToFile(filename string, info *ExportInfo, remote string, index int) {
 
 	height := 10
 	width := 70
+
+	var buf string
 
 	if len(info.Input.YValues) > 0 {
 		caption := fmt.Sprintf("Input Mbps: %s Connection %d", remote, index)
 		log.Printf("%s input:", remote)
 		input := asciigraph.Plot(info.Input.YValues, asciigraph.Caption(caption), asciigraph.Height(height), asciigraph.Width(width))
 		fmt.Println(input)
+		buf += input + "\n"
 	}
 
 	if len(info.Output.YValues) > 0 {
@@ -24,5 +28,12 @@ func plotascii(info *ExportInfo, remote string, index int) {
 		log.Printf("%s output:", remote)
 		output := asciigraph.Plot(info.Output.YValues, asciigraph.Caption(caption), asciigraph.Height(height), asciigraph.Width(width))
 		fmt.Println(output)
+		buf += output + "\n"
+	}
+
+	if filename != "" && buf != "" {
+		if err := os.WriteFile(filename, []byte(buf), 0644); err != nil {
+			log.Printf("plotascii: write file %s: %v", filename, err)
+		}
 	}
 }

--- a/goben/server.go
+++ b/goben/server.go
@@ -92,7 +92,7 @@ func listenTCP(ctx context.Context, app *Config, wg *sync.WaitGroup, h string) b
 		if app.TLS {
 			log.Printf("listenTCP: falling back to TCP and spawning TCP listener: %s", h)
 		} else {
-			log.Printf("listenTCP: spawning TLS listener: %s", h)
+			log.Printf("listenTCP: spawning TCP listener: %s", h)
 		}
 		listener, errListen := net.Listen("tcp", h)
 		if errListen != nil {

--- a/test/scripts/export_test.sh
+++ b/test/scripts/export_test.sh
@@ -1,0 +1,228 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+BIN_DIR="/tmp/goben_test_bins"
+OUTPUT_DIR="$PROJECT_DIR/test/output"
+
+cleanup() {
+    rm -rf "$BIN_DIR"
+    pkill -f "goben_test_server" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+build() {
+    echo "[build] compiling binaries..."
+    mkdir -p "$BIN_DIR" "$OUTPUT_DIR"
+    go build -o "$BIN_DIR/goben_test_client" "$PROJECT_DIR/cmd/goben"
+    cp "$BIN_DIR/goben_test_client" "$BIN_DIR/goben_test_server"
+}
+
+wait_for_server() {
+    local port=$1
+    local max=10
+    local i
+    for ((i = 0; i < max; i++)); do
+        if ss -tlnp 2>/dev/null | grep -q ":${port} "; then
+            return 0
+        fi
+        sleep 0.5
+    done
+    echo "[FAIL] server on port $port did not start"
+    return 1
+}
+
+run_server() {
+    local port=$1
+    "$BIN_DIR/goben_test_server" \
+        -l "127.0.0.1:$port" \
+        -s=false -t=true -u=false &
+    wait_for_server "$port"
+}
+
+assert_files_exist() {
+    for f in "$@"; do
+        local path="$OUTPUT_DIR/$f"
+        if [ ! -f "$path" ]; then
+            echo "[FAIL] file not found: $path"
+            return 1
+        fi
+        echo "[OK]   $f ($(stat -c%s "$path") bytes)"
+    done
+}
+
+assert_files_not_exist() {
+    for f in "$@"; do
+        local path="$OUTPUT_DIR/$f"
+        if [ -f "$path" ]; then
+            echo "[FAIL] file should not exist: $path"
+            return 1
+        fi
+    done
+}
+
+assert_no_malformed_files() {
+    local count
+    count=$(find "$OUTPUT_DIR" -maxdepth 1 -name '*!\(*' 2>/dev/null | wc -l)
+    if [ "$count" -gt 0 ]; then
+        echo "[FAIL] found files with malformed names:"
+        find "$OUTPUT_DIR" -maxdepth 1 -name '*!\(*'
+        return 1
+    fi
+}
+
+run_client() {
+    (cd "$OUTPUT_DIR" && "$BIN_DIR/goben_test_client" "$@")
+}
+
+test_default_ascii_console_only() {
+    echo ""
+    echo "=== Test: default behavior (no --export) outputs ASCII to console only ==="
+    local port=19001
+
+    run_server "$port"
+    run_client \
+        -H "127.0.0.1:$port" \
+        -s=false -t=true -u=false \
+        -d 3s 2>&1 | grep -E "input:|output:" || true
+
+    assert_files_not_exist "result-0-127.0.0.1:$port.ascii"
+    echo "[OK]   no file written for default ASCII (console only)"
+    pkill -f "goben_test_server" 2>/dev/null || true
+    sleep 0.5
+}
+
+test_explicit_ascii_writes_file() {
+    echo ""
+    echo "=== Test: --export ascii writes to console AND file ==="
+    local port=19002
+
+    run_server "$port"
+    run_client \
+        -H "127.0.0.1:$port" \
+        -s=false -t=true -u=false \
+        -d 3s \
+        --export ascii 2>&1 | grep -E "input:|output:" || true
+
+    assert_files_exist "result-0-127.0.0.1:$port.ascii"
+    pkill -f "goben_test_server" 2>/dev/null || true
+    sleep 0.5
+}
+
+test_comma_separated_modes() {
+    echo ""
+    echo "=== Test: -e csv,yaml,png generates all three files ==="
+    local port=19003
+
+    run_server "$port"
+    run_client \
+        -H "127.0.0.1:$port" \
+        -s=false -t=true -u=false \
+        -d 3s \
+        -e csv,yaml,png 2>&1 | grep -E "export|render" || true
+
+    assert_files_exist \
+        "result-0-127.0.0.1:$port.csv" \
+        "result-0-127.0.0.1:$port.yaml" \
+        "result-0-127.0.0.1:$port.png"
+    assert_files_not_exist "result-0-127.0.0.1:$port.ascii"
+
+    pkill -f "goben_test_server" 2>/dev/null || true
+    sleep 0.5
+}
+
+test_repeated_flags() {
+    echo ""
+    echo "=== Test: -e X.yaml -e X.png -e X.csv with fixed filenames ==="
+    local port=19004
+
+    run_server "$port"
+    run_client \
+        -H "127.0.0.1:$port" \
+        -s=false -t=true -u=false \
+        -d 3s \
+        -e mytest.yaml -e mytest.png -e mytest.csv 2>&1 | grep -E "export|render" || true
+
+    assert_files_exist mytest.yaml mytest.png mytest.csv
+    assert_no_malformed_files
+
+    pkill -f "goben_test_server" 2>/dev/null || true
+    sleep 0.5
+}
+
+test_all_formats() {
+    echo ""
+    echo "=== Test: -e csv,yaml,png,ascii generates all four files ==="
+    local port=19005
+
+    run_server "$port"
+    run_client \
+        -H "127.0.0.1:$port" \
+        -s=false -t=true -u=false \
+        -d 3s \
+        -e csv,yaml,png,ascii 2>&1 | grep -E "export|render" || true
+
+    assert_files_exist \
+        "result-0-127.0.0.1:$port.csv" \
+        "result-0-127.0.0.1:$port.yaml" \
+        "result-0-127.0.0.1:$port.png" \
+        "result-0-127.0.0.1:$port.ascii"
+
+    pkill -f "goben_test_server" 2>/dev/null || true
+    sleep 0.5
+}
+
+test_mixed_modes_and_filenames() {
+    echo ""
+    echo "=== Test: -e ascii,result-%d-%s.csv,myreport.png mixed formats ==="
+    local port=19006
+
+    run_server "$port"
+    run_client \
+        -H "127.0.0.1:$port" \
+        -s=false -t=true -u=false \
+        -d 3s \
+        -e "ascii,result-%d-%s.csv,myreport.png" 2>&1 | grep -E "export|render" || true
+
+    assert_files_exist \
+        "result-0-127.0.0.1:$port.ascii" \
+        "result-0-127.0.0.1:$port.csv" \
+        "myreport.png"
+
+    pkill -f "goben_test_server" 2>/dev/null || true
+    sleep 0.5
+}
+
+main() {
+    cd "$PROJECT_DIR"
+    build
+
+    PASSED=0
+    FAILED=0
+
+    for test_fn in \
+        test_default_ascii_console_only \
+        test_explicit_ascii_writes_file \
+        test_comma_separated_modes \
+        test_repeated_flags \
+        test_all_formats \
+        test_mixed_modes_and_filenames; do
+        if $test_fn; then
+            PASSED=$((PASSED + 1))
+        else
+            FAILED=$((FAILED + 1))
+        fi
+    done
+
+    echo ""
+    echo "==============================="
+    echo "  PASSED: $PASSED  FAILED: $FAILED"
+    echo "==============================="
+
+    if [ "$FAILED" -gt 0 ]; then
+        exit 1
+    fi
+}
+
+main "$@"


### PR DESCRIPTION
**1. Refactor CLI: migrate from flag to pflag with shorthand support**

- Replace stdlib flag with github.com/spf13/pflag
- Add shorthand flags: -H/-l/-p/-c/-i/-d/-m/-u/-s/-t/-a/-e
- Change DefaultPort from string to int (default 8080)
- Improve help descriptions for all flags
- Update README with actual help output and examples

**2. Replace magic number export modes (0-4) with a string-based --export flag
that supports comma/pipe-separated combinations of ascii, csv, yaml, png.**

Key changes:
- Merge --export and --exportFile into a single --export flag
- Support multi-format output (e.g. --export ascii,csv,yaml)
- Support file extension auto-detection (e.g. --export result.yaml)
- Case-insensitive mode keywords with regex validation
- Pure mode keywords auto-generate filenames (e.g. csv → result-%d-%s.csv)
- ASCII is the default output when --export is not specified (console only)
- Explicit --export ascii writes to both console and file
- NoOptDefVal: bare --export defaults to ascii

<img width="1686" height="804" alt="image" src="https://github.com/user-attachments/assets/79aeb34d-d740-4ead-83af-14e337f15c75" />
<img width="2616" height="765" alt="image" src="https://github.com/user-attachments/assets/1e748d71-3728-4e11-b018-ccc8227af783" />





